### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.9](https://github.com/cartercanedy/rawbit/compare/v0.1.8...v0.1.9) - 2024-12-16
+
+### Fixed
+- *(CI)* use PAT for release workflows (by @cartercanedy)
+
+### Contributors
+
+* @cartercanedy
 ## [0.1.8](https://github.com/cartercanedy/rawbit/compare/v0.1.7...v0.1.8) - 2024-12-16
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rawbit"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "clap",

--- a/rawbit/Cargo.toml
+++ b/rawbit/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["multimedia::encoding", "multimedia::images", "command-line-utilit
 keywords = ["imaging", "photography", "camera-RAW", "RAW"]
 license = "MIT"
 repository = "https://github.com/cartercanedy/rawbit"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 readme = "../README.md"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rawbit = { version = "0.1.8", path = "../rawbit" }
+rawbit = { version = "0.1.9", path = "../rawbit" }


### PR DESCRIPTION
## 🤖 New release
* `rawbit`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/cartercanedy/rawbit/compare/v0.1.8...v0.1.9) - 2024-12-16

### Fixed
- *(CI)* use PAT for release workflows (by @cartercanedy)

### Contributors

* @cartercanedy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).