### PR TITLE
chore: release v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.13](https://github.com/cartercanedy/rawbit/compare/v0.1.12...v0.1.13) - 2025-01-21
+
+### Miscellaneous
+- *(ignore)* Bump clap from 4.5.23 to 4.5.27 (#43)
+
+### Contributors
+
+* @dependabot[bot]
 ## [0.1.12](https://github.com/cartercanedy/rawbit/compare/v0.1.11...v0.1.12) - 2024-12-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rawbit"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rawbit/Cargo.toml
+++ b/rawbit/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["multimedia::encoding", "multimedia::images", "command-line-utilit
 keywords = ["imaging", "photography", "camera-RAW", "RAW"]
 license = "MIT"
 repository = "https://github.com/cartercanedy/rawbit"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 readme = "../README.md"
 

--- a/rawbit/Cargo.toml
+++ b/rawbit/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 [dependencies]
 async-trait = "0.1.83"
 chrono = { version = "0.4.39", default-features = false, features = ["std", "winapi"] }
-clap = { version = "4.5.23", features = ["derive", "env", "string", "unicode"] }
+clap = { version = "4.5.27", features = ["derive", "env", "string", "unicode"] }
 futures = "0.3.31"
 phf = { version = "0.11.2", features = ["macros"] }
 rawler = "0.6.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 clap = "4.5.27"
-rawbit = { version = "0.1.12", path = "../rawbit" }
+rawbit = { version = "0.1.13", path = "../rawbit" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-clap = "4.5.23"
+clap = "4.5.27"
 rawbit = { version = "0.1.12", path = "../rawbit" }


### PR DESCRIPTION
## 🤖 New release
* `rawbit`: 0.1.12 -> 0.1.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.13](https://github.com/cartercanedy/rawbit/compare/v0.1.12...v0.1.13) - 2025-01-21

### Miscellaneous
- *(ignore)* Bump clap from 4.5.23 to 4.5.27 (#43)

### Contributors

* @dependabot[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).