### PR TITLE
chore: release v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.14](https://github.com/cartercanedy/rawbit/compare/v0.1.13...v0.1.14) - 2025-04-08
+
+### Security
+- *(tokio)* address tokio CVE
+
+### Contributors
+
+* @dependabot[bot]
 ## [0.1.13](https://github.com/cartercanedy/rawbit/compare/v0.1.12...v0.1.13) - 2025-02-09
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rawbit"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rawbit/Cargo.toml
+++ b/rawbit/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["multimedia::encoding", "multimedia::images", "command-line-utilit
 keywords = ["imaging", "photography", "camera-RAW", "RAW"]
 license = "MIT"
 repository = "https://github.com/cartercanedy/rawbit"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 readme = "../README.md"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 clap = "4.5.35"
-rawbit = { version = "0.1.13", path = "../rawbit" }
+rawbit = { version = "0.1.14", path = "../rawbit" }


### PR DESCRIPTION



## 🤖 New release

* `rawbit`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.14](https://github.com/cartercanedy/rawbit/compare/v0.1.13...v0.1.14) - 2025-04-08

### Security
- *(tokio)* address tokio CVE

### Contributors

* @dependabot[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).