### PR TITLE
chore: release v0.1.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "rawbit"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rawbit/Cargo.toml
+++ b/rawbit/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["multimedia::encoding", "multimedia::images", "command-line-utilit
 keywords = ["imaging", "photography", "camera-RAW", "RAW"]
 license = "MIT"
 repository = "https://github.com/cartercanedy/rawbit"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 readme = "../README.md"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 clap = "4.5.37"
-rawbit = { version = "0.1.14", path = "../rawbit" }
+rawbit = { version = "0.1.15", path = "../rawbit" }


### PR DESCRIPTION



## 🤖 New release

* `rawbit`: 0.1.14 -> 0.1.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.14](https://github.com/cartercanedy/rawbit/compare/v0.1.13...v0.1.14) - 2025-04-08

### Security
- *(tokio)* address tokio CVE

### Contributors

* @dependabot[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).