### PR TITLE
chore: release v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 
+## [0.1.18](https://github.com/cartercanedy/rawbit/compare/v0.1.17...v0.1.18) - 2026-06-03
+
+### Fixed
+- use original format string for error reports ([#121](https://github.com/cartercanedy/rawbit/pull/121)) (by @cartercanedy) - #121
+
+### Other
+- update README (by @cartercanedy)
+
+### Contributors
+
+* @cartercanedy
+
 ## [0.1.16](https://github.com/cartercanedy/rawbit/compare/v0.1.15...v0.1.16) - 2025-12-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rawbit"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rawbit/Cargo.toml
+++ b/rawbit/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["multimedia::encoding", "multimedia::images", "command-line-utilit
 keywords = ["imaging", "photography", "camera-RAW", "RAW"]
 license = "MIT"
 repository = "https://github.com/cartercanedy/rawbit"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 readme = "../README.md"
 

--- a/rawbit/src/parse.rs
+++ b/rawbit/src/parse.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, cell::LazyCell, error, fmt};
 use chrono::NaiveDateTime;
 use phf::{Map, phf_map};
 use rawler::decoders::RawMetadata;
-use smlog::warn;
+use smlog::{log, warn};
 use zips::zip;
 
 use crate::common::{AppError, RawbitResult};
@@ -224,7 +224,7 @@ impl<'a> FilenameFormat<'a> {
                                 return Err(AppError::FmtStrParse(Error::invalid_expansion(
                                     consumed,
                                     s.len(),
-                                    to_parse,
+                                    fmt,
                                 )));
                             }
 
@@ -234,16 +234,18 @@ impl<'a> FilenameFormat<'a> {
                         ScanState::ExpansionBody => {
                             assert!(
                                 s.starts_with(OPEN_EXPANSION),
-                                "An expansion was interpreted incorrectly: fmt: {to_parse}, seq: {s}"
+                                "An expansion was interpreted incorrectly: fmt: {fmt}, seq: {s}"
                             );
 
                             if s.ends_with(CLOSE_EXPANSION) {
-                                expand(&s[1..s.len() - 1]).ok_or(AppError::FmtStrParse(
-                                    Error::invalid_expansion(consumed, s.len(), to_parse),
-                                ))?
+                                expand(&s[1..s.len() - 1]).ok_or_else(|| {
+                                    AppError::FmtStrParse(
+                                        Error::invalid_expansion(consumed, s.len(), fmt),
+                                    )
+                                })?
                             } else {
                                 return Err(AppError::FmtStrParse(
-                                    Error::unterminated_expansion(consumed, s.len(), to_parse),
+                                    Error::unterminated_expansion(consumed, s.len(), fmt),
                                 ));
                             }
                         }
@@ -257,7 +259,7 @@ impl<'a> FilenameFormat<'a> {
                 return Err(AppError::FmtStrParse(Error::new(
                     consumed,
                     to_parse.len() - consumed,
-                    to_parse,
+                    fmt,
                     ErrorKind::Unknown,
                 )));
             }
@@ -280,9 +282,8 @@ fn expand(s: &str) -> Option<FmtItem<'_>> {
 
 #[cfg(test)]
 mod test_parse {
-    use crate::parse::FilenameFormat;
+    use super::{FmtItem, MetadataKind, OPEN_EXPANSION, FilenameFormat};
 
-    use super::{FmtItem, MetadataKind, OPEN_EXPANSION};
     #[test]
     fn parses_expansions_and_strftime_ok() {
         assert!(FilenameFormat::parse("%Y-%m-%d_{camera.make}").is_ok());
@@ -421,3 +422,4 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {}
+

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 clap = "4.5.50"
-rawbit = { version = "0.1.17", path = "../rawbit" }
+rawbit = { version = "0.1.18", path = "../rawbit" }


### PR DESCRIPTION



## 🤖 New release

* `rawbit`: 0.1.17 -> 0.1.18

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.18](https://github.com/cartercanedy/rawbit/compare/v0.1.17...v0.1.18) - 2026-06-03

### Fixed
- use original format string for error reports ([#121](https://github.com/cartercanedy/rawbit/pull/121)) (by @cartercanedy) - #121

### Other
- update README (by @cartercanedy)

### Contributors

* @cartercanedy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).