### PR TITLE
chore: release v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 
+## [0.1.18](https://github.com/cartercanedy/rawbit/compare/v0.1.17...v0.1.18) - 2026-06-03
+
+### Fixed
+- use original format string for error reports ([#121](https://github.com/cartercanedy/rawbit/pull/121)) (by @cartercanedy)
+
+### Other
+- update README (by @cartercanedy)
+
+### Contributors
+
+* @cartercanedy
+
 ## [0.1.16](https://github.com/cartercanedy/rawbit/compare/v0.1.15...v0.1.16) - 2025-12-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rawbit"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rawbit/Cargo.toml
+++ b/rawbit/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["multimedia::encoding", "multimedia::images", "command-line-utilit
 keywords = ["imaging", "photography", "camera-RAW", "RAW"]
 license = "MIT"
 repository = "https://github.com/cartercanedy/rawbit"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 readme = "../README.md"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 clap = "4.5.50"
-rawbit = { version = "0.1.17", path = "../rawbit" }
+rawbit = { version = "0.1.18", path = "../rawbit" }


### PR DESCRIPTION



## 🤖 New release

* `rawbit`: 0.1.17 -> 0.1.18

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.18](https://github.com/cartercanedy/rawbit/compare/v0.1.17...v0.1.18) - 2026-06-03

### Fixed
- use original format string for error reports ([#121](https://github.com/cartercanedy/rawbit/pull/121)) (by @cartercanedy)

### Other
- update README (by @cartercanedy)

### Contributors

* @cartercanedy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).